### PR TITLE
Registration notebook

### DIFF
--- a/notebooks/Reg/sirf_registration.ipynb
+++ b/notebooks/Reg/sirf_registration.ipynb
@@ -252,58 +252,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deformation field\n",
-    "The deformation field will be a 3D tensor image, where the components are the deformation in the x-, y- and z-directions, respectively.\n",
+    "## Displacement field image\n",
+    "The displacement field image maps the voxels of the floating image to the final warped image. They are particularly interesting for non-rigid registrations, where transformation matrices no longer exist.\n",
     "\n",
-    "In the NIfTI format, the number of voxels in each of the dimensions is shown as a 8-dimensional array. The elements represent the following:\n",
-    "```\n",
-    "dim[0] = number of dimensions\n",
-    "dim[1] = x\n",
-    "dim[2] = y\n",
-    "dim[3] = z\n",
-    "dim[4] = t (time)\n",
-    "dim[5] = u (tensor component)\n",
-    "dim[6] = v\n",
-    "dim[7] = w\n",
-    "```\n",
-    "For a deformation field, the tensor information is stored in the `u` dimension. So we would expect `deformation.get_dimensions()` to give `[5 x y z 1 3 1 1]` (5 because the 5th dimension is the last non-singleton dimension)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deformation = algo.get_deformation_field_forward()\n",
-    "print(\"Deformation NIfTI dimensions\")\n",
-    "print(deformation.get_dimensions())\n",
-    "print(\"Deformation NIfTI dimensions as a numpy array (using shape)\")\n",
-    "def_arr = deformation.as_array()\n",
-    "print(def_arr.shape)\n",
-    "plt.subplot(3,1,1);\n",
-    "imshow(deformation.as_array()[ref_slice,:,:,0,0], 'Deformation field x-direction, slice: %i' % int(ref_slice));\n",
-    "plt.subplot(3,1,2);\n",
-    "imshow(deformation.as_array()[ref_slice,:,:,0,1], 'Deformation field y-direction, slice: %i' % int(ref_slice));\n",
-    "plt.subplot(3,1,3);\n",
-    "imshow(deformation.as_array()[ref_slice,:,:,0,2], 'Deformation field z-direction, slice: %i' % int(ref_slice));"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Displacement field\n",
+    "Each voxel of the displacement field image contains an (x,y,z) coordinate, so the resulting image is 4D.\n",
     "\n",
-    "The displacement field is mostly the same as the deformation field, and the x-, y- and z-components can be displayed.\n",
-    "\n",
-    "#### What's the difference between displacement and deformation fields?\n",
-    "From an input image, <b>`x`</b>, the warped image, <b>`W`</b>, can be generated with either a deformation or displacement field.\n",
-    "The formulae for the two are given below:\n",
-    "<pre>\n",
-    "<b>W</b>(<b>x</b>) = <b>x</b> + disp(<b>x</b>)\n",
-    "<b>W</b>(<b>x</b>) = def(<b>x</b>)\n",
-    "</pre>"
+    "(As a small technicality, the NIfTI format stores the time component in the 4th dimension, and the displacement coordinates in the 5th dimension. Therefore the displacement field image is actually a 5D image with a singleton in the 4th dimension.)"
    ]
   },
   {

--- a/notebooks/Reg/sirf_registration.ipynb
+++ b/notebooks/Reg/sirf_registration.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rigid registration\n",
+    "\n",
+    "This example should show you how to perform rigid registration between two SIRF images.\n",
+    "\n",
+    "SIRF's registration/resampling functionality is provided by wrapping and extending the [NiftyReg](http://cmictig.cs.ucl.ac.uk/wiki/index.php/NiftyReg) code base. Rigid and affine registrations are performed using NiftyReg's symmetric `aladin` algorithm, whereas non-rigid registrations use the symmetric `f3d` algorithm.\n",
+    "\n",
+    "Although the example of rigid registration is given here, it is trivial to modify it for affine registrations and only slightly trickier to extend to non-rigid registration.\n",
+    "\n",
+    "The images to be registered in this example are `test.nii.gz` and `test2.nii.gz`, which are two T1-weighted MR brain scans taken one year apart.\n",
+    "\n",
+    "N.B.: Registration packages use different names for the sets of images they are registering. In NiftyReg (and therefore SIRF), the floating image is moved to match the reference image. In other packages, the floating=moving and reference=fixed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Copyright\n",
+    "\n",
+    "Author: Richard Brown\n",
+    "First version: 3rd April 2019\n",
+    "\n",
+    "CCP PETMR Synergistic Image Reconstruction Framework (SIRF)\n",
+    "Copyright 2019 University College London.\n",
+    "\n",
+    "This is software developed for the Collaborative Computational Project in Positron Emission Tomography and Magnetic Resonance imaging (http://www.ccppetmr.ac.uk/).\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initial set up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Standard stuff\n",
+    "import numpy\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib notebook\n",
+    "\n",
+    "# SIRF stuff\n",
+    "from sirf.Utilities import examples_data_path\n",
+    "import sirf.Reg as Reg\n",
+    "examples_path = examples_data_path('Registration')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%% First define some handy function definitions\n",
+    "# To make subsequent code cleaner, we have a few functions here. You can ignore\n",
+    "# ignore them when you first see this demo.\n",
+    "# They have (minimal) documentation using Python docstrings such that you \n",
+    "# can do for instance \"help(imshow)\"\n",
+    "#\n",
+    "# First a function to display an image\n",
+    "\n",
+    "def imshow(image, title=''):\n",
+    "    \"\"\"Display an image with a colourbar, returning the plot handle. \n",
+    "    \n",
+    "    Arguments:\n",
+    "    image -- a 2D array of numbers\n",
+    "    limits -- colourscale limits as [min,max]. An empty [] uses the full range\n",
+    "    title -- a string for the title of the plot (default \"\")\n",
+    "    \"\"\"\n",
+    "    plt.title(title)\n",
+    "    bitmap=plt.imshow(image)\n",
+    "    limits=[numpy.nanmin(image),numpy.nanmax(image)]\n",
+    "                \n",
+    "    plt.clim(limits[0], limits[1])\n",
+    "    plt.colorbar(shrink=.6)\n",
+    "    plt.axis('off');\n",
+    "    return bitmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Engine for loading images\n",
+    "\n",
+    "By default this example uses `pReg` as the engine to open the images, which handles NIfTI images. \n",
+    "\n",
+    "You might want to register different types of images - perhaps your floating image is a STIR interfile? If so, change the second line such that it reads `import pSTIR as eng_flo`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In this example, we will use pReg as the engine to open our images\n",
+    "import sirf.Reg as eng_ref\n",
+    "import sirf.Reg as eng_flo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Open and display the images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the images\n",
+    "ref_file = examples_path + \"/test.nii.gz\"\n",
+    "flo_file = examples_path + \"/test2.nii.gz\"\n",
+    "ref = eng_ref.ImageData(ref_file)\n",
+    "flo = eng_flo.ImageData(flo_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the images\n",
+    "ref_slice = int(ref.get_dimensions()[1]/2);\n",
+    "flo_slice = int(flo.get_dimensions()[1]/2);\n",
+    "plt.subplot(1,2,1);\n",
+    "imshow(ref.as_array()[ref_slice,:,:], 'Reference image, slice: %i' % int(ref_slice));\n",
+    "plt.subplot(1,2,2);\n",
+    "imshow(flo.as_array()[flo_slice,:,:], 'Floating image, slice: %i' % int(flo_slice));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up the registration object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set to NiftyF3dSym for non-rigid\n",
+    "algo = Reg.NiftyAladinSym()\n",
+    "\n",
+    "# Set images\n",
+    "algo.set_reference_image(ref)\n",
+    "algo.set_floating_image(flo)\n",
+    "\n",
+    "# What else can we do?\n",
+    "help(algo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting parameters\n",
+    "\n",
+    "From the help above, it looks like we can set registration parameters both via a file and directly. Let's try both."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setting via parameter file\n",
+    "par_file = examples_path + \"/paramFiles/niftyreg_aladin.par\"\n",
+    "algo.set_parameter_file(par_file)\n",
+    "\n",
+    "algo.set_parameter('SetPerformRigid','1')\n",
+    "algo.set_parameter('SetPerformAffine','0')\n",
+    "#algo.set_parameter('SetWarpedPaddingValue','0') <- NaN by default, uncomment to set to 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Register!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "algo.process()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show the registered image\n",
+    "\n",
+    "The registered image will be the same size as the reference image, so we can use `ref_slice`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = algo.get_output()\n",
+    "output_arr = output.as_array()\n",
+    "imshow(output_arr[ref_slice,:,:], 'Registered image, slice: %i' % int(ref_slice));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show the transformation matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TM = algo.get_transformation_matrix_forward()\n",
+    "print(TM.as_array())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deformation field\n",
+    "The deformation field will be a 3D tensor image, where the components are the deformation in the x-, y- and z-directions, respectively.\n",
+    "\n",
+    "In the NIfTI format, the number of voxels in each of the dimensions is shown as a 8-dimensional array. The elements represent the following:\n",
+    "```\n",
+    "dim[0] = number of dimensions\n",
+    "dim[1] = x\n",
+    "dim[2] = y\n",
+    "dim[3] = z\n",
+    "dim[4] = t (time)\n",
+    "dim[5] = u (tensor component)\n",
+    "dim[6] = v\n",
+    "dim[7] = w\n",
+    "```\n",
+    "For a deformation field, the tensor information is stored in the `u` dimension. So we would expect `deformation.get_dimensions()` to give `[5 x y z 1 3 1 1]` (5 because the 5th dimension is the last non-singleton dimension)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deformation = algo.get_deformation_field_forward()\n",
+    "print(\"Deformation NIfTI dimensions\")\n",
+    "print(deformation.get_dimensions())\n",
+    "print(\"Deformation NIfTI dimensions as a numpy array (using shape)\")\n",
+    "def_arr = deformation.as_array()\n",
+    "print(def_arr.shape)\n",
+    "plt.subplot(3,1,1);\n",
+    "imshow(deformation.as_array()[ref_slice,:,:,0,0], 'Deformation field x-direction, slice: %i' % int(ref_slice));\n",
+    "plt.subplot(3,1,2);\n",
+    "imshow(deformation.as_array()[ref_slice,:,:,0,1], 'Deformation field y-direction, slice: %i' % int(ref_slice));\n",
+    "plt.subplot(3,1,3);\n",
+    "imshow(deformation.as_array()[ref_slice,:,:,0,2], 'Deformation field z-direction, slice: %i' % int(ref_slice));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Displacement field\n",
+    "\n",
+    "The displacement field is mostly the same as the deformation field, and the x-, y- and z-components can be displayed.\n",
+    "\n",
+    "#### What's the difference between displacement and deformation fields?\n",
+    "From an input image, <b>`x`</b>, the warped image, <b>`W`</b>, can be generated with either a deformation or displacement field.\n",
+    "The formulae for the two are given below:\n",
+    "<pre>\n",
+    "<b>W</b>(<b>x</b>) = <b>x</b> + disp(<b>x</b>)\n",
+    "<b>W</b>(<b>x</b>) = def(<b>x</b>)\n",
+    "</pre>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "displacement = algo.get_displacement_field_forward()\n",
+    "plt.subplot(3,1,1);\n",
+    "imshow(displacement.as_array()[ref_slice,:,:,0,0], 'Displacement field x-direction, slice: %i' % int(ref_slice));\n",
+    "plt.subplot(3,1,2);\n",
+    "imshow(displacement.as_array()[ref_slice,:,:,0,1], 'Displacement field y-direction, slice: %i' % int(ref_slice));\n",
+    "plt.subplot(3,1,3);\n",
+    "imshow(displacement.as_array()[ref_slice,:,:,0,2], 'Displacement field z-direction, slice: %i' % int(ref_slice));"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Reg/sirf_registration.ipynb
+++ b/notebooks/Reg/sirf_registration.ipynb
@@ -139,12 +139,12 @@
    "outputs": [],
    "source": [
     "# Display the images\n",
-    "ref_slice = int(ref.get_dimensions()[1]/2);\n",
-    "flo_slice = int(flo.get_dimensions()[1]/2);\n",
+    "ref_slice = ref.get_dimensions()[1] // 2;\n",
+    "flo_slice = flo.get_dimensions()[1] // 2;\n",
     "plt.subplot(1,2,1);\n",
-    "imshow(ref.as_array()[ref_slice,:,:], 'Reference image, slice: %i' % int(ref_slice));\n",
+    "imshow(ref.as_array()[ref_slice,:,:], 'Reference image, slice: %i' % ref_slice);\n",
     "plt.subplot(1,2,2);\n",
-    "imshow(flo.as_array()[flo_slice,:,:], 'Floating image, slice: %i' % int(flo_slice));"
+    "imshow(flo.as_array()[flo_slice,:,:], 'Floating image, slice: %i' % flo_slice);"
    ]
   },
   {
@@ -228,7 +228,7 @@
    "source": [
     "output = algo.get_output()\n",
     "output_arr = output.as_array()\n",
-    "imshow(output_arr[ref_slice,:,:], 'Registered image, slice: %i' % int(ref_slice));"
+    "imshow(output_arr[ref_slice,:,:], 'Registered image, slice: %i' % ref_slice);"
    ]
   },
   {
@@ -268,11 +268,11 @@
    "source": [
     "displacement = algo.get_displacement_field_forward()\n",
     "plt.subplot(3,1,1);\n",
-    "imshow(displacement.as_array()[ref_slice,:,:,0,0], 'Displacement field x-direction, slice: %i' % int(ref_slice));\n",
+    "imshow(displacement.as_array()[ref_slice,:,:,0,0], 'Displacement field x-direction, slice: %i' % ref_slice);\n",
     "plt.subplot(3,1,2);\n",
-    "imshow(displacement.as_array()[ref_slice,:,:,0,1], 'Displacement field y-direction, slice: %i' % int(ref_slice));\n",
+    "imshow(displacement.as_array()[ref_slice,:,:,0,1], 'Displacement field y-direction, slice: %i' % ref_slice);\n",
     "plt.subplot(3,1,3);\n",
-    "imshow(displacement.as_array()[ref_slice,:,:,0,2], 'Displacement field z-direction, slice: %i' % int(ref_slice));"
+    "imshow(displacement.as_array()[ref_slice,:,:,0,2], 'Displacement field z-direction, slice: %i' % ref_slice);"
    ]
   }
  ],


### PR DESCRIPTION
Simple example to do registration in SIRF. 
The example performs rigid registration of two T1-weighted MR brain scans.